### PR TITLE
0.6.2 initial

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ test:
   requires:
     - pip
     - pytest >=6.1
-    - pytest-httpserver >=1.0.4
     - flask >=2.1.2
     - requests-wsgi-adapter >=0.4.1
     - trustme >=0.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,21 +33,21 @@ requirements:
 test:
   imports:
     - unearth
-#  pytest disabled pending trustme 0.9.0
-#  source_files:
-#    - tests
+  pytest disabled pending trustme 0.9.0
+  source_files:
+    - tests
   commands:
-#    - pytest tests
+    - pytest tests
     - pip check
   requires:
     - pip
-#    - pytest >=6.1
-#    - pytest-httpserver >=1.0.4
-#    - flask >=2.1.2
-#    - requests-wsgi-adapter >=0.4.1
-#    - trustme >=0.9.0
-#    - keyring
-#    - openssl <3.0.0
+    - pytest >=6.1
+    - pytest-httpserver >=1.0.4
+    - flask >=2.1.2
+    - requests-wsgi-adapter >=0.4.1
+    - trustme >=0.9.0
+    - keyring
+    - openssl <3.0.0
 
 about:
   home: https://pypi.org/project/unearth/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,8 @@ test:
   source_files:
     - tests
   commands:
-    - pytest tests
+  # Skipping test_session_with_selfsigned_ca because pytest-httpserver is not on defaults
+    - pytest tests -k "not test_session_with_selfsigned_ca"
     - pip check
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,19 +33,20 @@ requirements:
 test:
   imports:
     - unearth
-  source_files:
-    - tests
+#  source_files:
+#    - tests
   commands:
-    - pytest tests
+#    - pytest tests
+    - pip check
   requires:
     - pip
-    - pytest >=6.1
-    - pytest-httpserver >=1.0.4
-    - flask >=2.1.2
-    - requests-wsgi-adapter >=0.4.1
-    - trustme >=0.9.0
-    - keyring
-    - openssl <3.0.0
+#    - pytest >=6.1
+#    - pytest-httpserver >=1.0.4
+#    - flask >=2.1.2
+#    - requests-wsgi-adapter >=0.4.1
+#    - trustme >=0.9.0
+#    - keyring
+#    - openssl <3.0.0
 
 about:
   home: https://pypi.org/project/unearth/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 4b7bfbd7d34a11673d80dfae7fabbf921c139aac78383fb0ca16a90d3b53a66e
 
 build:
+  skip: true  # [py<37]
   script: 
     - {{ PYTHON }} -m pdm build -vv
     - {{ PYTHON }} -m pip install dist/unearth-{{ version }}-py3-none-any.whl -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
 build:
   skip: true  # [py<37]
   script: 
-    - {{ PYTHON }} -m pdm build -vv
-    - {{ PYTHON }} -m pip install dist/unearth-{{ version }}-py3-none-any.whl -vv
+    - python -m pip install --no-deps --ignore-installed .
   entry_points:
     - unearth = unearth.__main__:cli
   number: 0
@@ -22,7 +21,6 @@ requirements:
   host:
     - pip <22.2
     - python >=3.7
-    - pdm
     - pdm-pep517
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ requirements:
 test:
   imports:
     - unearth
-  pytest disabled pending trustme 0.9.0
   source_files:
     - tests
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,14 +20,14 @@ build:
 requirements:
   host:
     - pip <22.2
-    - python >=3.7
+    - python
     - pdm-pep517
     - setuptools
     - wheel
   run:
     - cached-property >=1.5.2
     - packaging >=20
-    - python >=3.7
+    - python
     - requests >=2.25
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,8 @@ test:
   source_files:
     - tests
   commands:
-  # Skipping test_session_with_selfsigned_ca because pytest-httpserver is not on defaults
     - pip check
+  # Skipping test_session_with_selfsigned_ca because pytest-httpserver is not on defaults
     - pytest tests -k "not test_session_with_selfsigned_ca"
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
 test:
   imports:
     - unearth
+#  pytest disabled pending trustme 0.9.0
 #  source_files:
 #    - tests
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unearth" %}
-{% set version = "0.6.1" %}
+{% set version = "0.6.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/unearth-{{ version }}.tar.gz
-  sha256: 4b7bfbd7d34a11673d80dfae7fabbf921c139aac78383fb0ca16a90d3b53a66e
+  sha256: 130d0c59159795ae66986c1dcbe5d2ddd1da19841972d8d73510d5204b3817ea
 
 build:
   skip: true  # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,12 @@ about:
   home: https://pypi.org/project/unearth/
   summary: A utility to fetch and download python packages
   license: MIT
-  license_file:
-    - LICENSE
+  license_family: MIT
+  license_file: LICENSE
+  license_url: https://github.com/frostming/unearth/blob/main/LICENSE
+  dev_url: https://github.com/frostming/unearth
+  doc_url: https://unearth.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/frostming/unearth/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 4b7bfbd7d34a11673d80dfae7fabbf921c139aac78383fb0ca16a90d3b53a66e
 
 build:
-  noarch: python
   script: 
     - {{ PYTHON }} -m pdm build -vv
     - {{ PYTHON }} -m pip install dist/unearth-{{ version }}-py3-none-any.whl -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,10 +53,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  license_url: https://github.com/frostming/unearth/blob/main/LICENSE
   dev_url: https://github.com/frostming/unearth
   doc_url: https://unearth.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/frostming/unearth/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ build:
 
 requirements:
   host:
+    - pip
     - python
     - pdm-pep517
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ build:
 
 requirements:
   host:
-    - pip <22.2
     - python
     - pdm-pep517
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,8 @@ test:
     - tests
   commands:
   # Skipping test_session_with_selfsigned_ca because pytest-httpserver is not on defaults
-    - pytest tests -k "not test_session_with_selfsigned_ca"
     - pip check
+    - pytest tests -k "not test_session_with_selfsigned_ca"
   requires:
     - pip
     - pytest >=6.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - cached-property >=1.5.2
+    - cached-property >=1.5.2  # [py<38]
     - packaging >=20
     - python
     - requests >=2.25

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - pdm
     - pdm-pep517
     - setuptools
+    - wheel
   run:
     - cached-property >=1.5.2
     - packaging >=20


### PR DESCRIPTION
Upstream repo: https://github.com/frostming/unearth
Jira issue: https://anaconda.atlassian.net/browse/PKG-704

Newly forked from conda-forge. Skipping `test_session_with_selfsigned_ca` because `pytest-httpserver` is not on defaults.