### PR TITLE
unearth 0.17.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,6 @@ requirements:
     - pip
     - python
     - pdm-backend
-    - setuptools
-    - wheel
   run:
     - httpx >=0.27.0,<1
     - packaging >=20

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<38]
   script:
-    - python -m pip install --no-deps --ignore-installed .
+    - python -m pip install --no-deps --no-build-isolation --ignore-installed .
   entry_points:
     - unearth = unearth.__main__:cli
   number: 0
@@ -50,11 +50,12 @@ test:
 about:
   home: https://pypi.org/project/unearth/
   summary: A utility to fetch and download python packages
+  description: A utility to fetch and download python packages
   license: MIT
   license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/frostming/unearth
-  doc_url: https://unearth.readthedocs.io/en/latest/
+  doc_url: https://unearth.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unearth" %}
-{% set version = "0.6.2" %}
+{% set version = "0.17.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/unearth-{{ version }}.tar.gz
-  sha256: 130d0c59159795ae66986c1dcbe5d2ddd1da19841972d8d73510d5204b3817ea
+  sha256: a19e1c02e64b40518d088079c7416fc41b45a648b81a4128aac02597234ee6ba
 
 build:
-  skip: true  # [py<37]
-  script: 
+  skip: true  # [py<38]
+  script:
     - python -m pip install --no-deps --ignore-installed .
   entry_points:
     - unearth = unearth.__main__:cli
@@ -21,14 +21,13 @@ requirements:
   host:
     - pip
     - python
-    - pdm-pep517
+    - pdm-backend
     - setuptools
     - wheel
   run:
-    - cached-property >=1.5.2  # [py<38]
+    - httpx >=0.27.0,<1
     - packaging >=20
     - python
-    - requests >=2.25
 
 test:
   imports:
@@ -44,9 +43,9 @@ test:
     - pytest >=6.1
     - flask >=2.1.2
     - requests-wsgi-adapter >=0.4.1
-    - trustme >=0.9.0
+    - trustme >=0.9.0  # [py<313]
     - keyring
-    - openssl <3.0.0
+    - pytest-mock >=3.12.0
 
 about:
   home: https://pypi.org/project/unearth/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,10 +37,11 @@ test:
   commands:
     - pip check
   # Skipping test_session_with_selfsigned_ca because pytest-httpserver is not on defaults
-    - pytest tests -k "not test_session_with_selfsigned_ca"
+    - pytest tests
   requires:
     - pip
     - pytest >=6.1
+    - pytest-httpserver >=1.0.4
     - flask >=2.1.2
     - requests-wsgi-adapter >=0.4.1
     - trustme >=0.9.0  # [py<313]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-9529](https://anaconda.atlassian.net/browse/PKG-9529)
- [Upstream repository](https://github.com/frostming/unearth/tree/0.17.5)
- [Upstream changelog/diff](https://github.com/frostming/unearth/releases)
- https://package-build.anaconda.com/v1/graph/21d93732-face-4079-a375-4193ba69b7b7

### Explanation of changes:

- Update version and sha256
- Update python skip
- Update dependencies


[PKG-9529]: https://anaconda.atlassian.net/browse/PKG-9529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ