### PR TITLE
Enable Python 3.14 support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - python -m pip install --no-deps --no-build-isolation --ignore-installed .
   entry_points:
     - unearth = unearth.__main__:cli
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
## Summary
- Add `abs.yaml` with `ANACONDA_ROCKET_ENABLE_PY314: yes` to enable Python 3.14 builds
- Bump build number from 0 to 1

Blocks https://github.com/AnacondaRecipes/conda-pypi-feedstock/pull/2

## Test plan
- [ ] Verify the ABS build triggers Python 3.14 builds
- [ ] Confirm the package builds and tests pass on Python 3.14